### PR TITLE
fix: include all needed data in site footer

### DIFF
--- a/components/SiteFooter.vue
+++ b/components/SiteFooter.vue
@@ -44,7 +44,7 @@ export default {
   async fetch() {
     this.courses = await this.$content('/', { deep: true })
       .where({ type: 'course' })
-      .only(['title'])
+      .only(['title', 'path'])
       .fetch()
 
   }

--- a/content/courses/library/index.md
+++ b/content/courses/library/index.md
@@ -1,4 +1,0 @@
----
-<!--stackedit_data:
-eyJoaXN0b3J5IjpbLTQ5NDQzMzcwMV19
--->


### PR DESCRIPTION
I fixed the horrible mishap created by the previous PR. This is a reminder to all of us to check preview URLs before merging PRs. Sorry.