### PR TITLE
Add scroll padding to the FAQ

### DIFF
--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -39,6 +39,13 @@ export default {
 }
 </script>
 
-<style scoped>
-
+<style >
+h2::before {
+  display: block;
+  content: " ";
+  margin-top: -70px;
+  height: 70px;
+  visibility: hidden;
+  pointer-events: none;
+}
 </style>


### PR DESCRIPTION
It looks like `scroll-padding` is only for scroll snapping, but I found a workaround [here](https://css-tricks.com/hash-tag-links-padding/).